### PR TITLE
Refactor/cli-parser-unify

### DIFF
--- a/src/pipeline/cleanup.py
+++ b/src/pipeline/cleanup.py
@@ -12,7 +12,11 @@ from pathlib import Path
 from typing import Dict, List, Tuple, Optional  # Iterable not used, remove it
 
 from src.utils.logging_utils import configure_logging, get_logger
-from src.utils.parser_utils import add_common_logging_args, add_common_cleanup_args
+from src.utils.parser_utils import (
+    add_common_logging_args, 
+    add_common_cleanup_args,
+    add_common_config_args,
+)
 from src.utils.paths import (
     VALIDATION_REPORTS_DIR,
     CLEANUP_REPORTS_DIR,
@@ -207,10 +211,8 @@ def _plan_moves(
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(
         description="Quarantine bad files based on a validate.py report (read-only consumer).")
-    parser.add_argument("--override", action="append", default=[],
-                        help="Override config values as key=val (e.g., policy=strict why=errors). Repeatable.")
-    parser.add_argument("--config", type=Path, default=None,
-                        help="Optional YAML config file (config-first).")
+    
+    add_common_config_args(parser)  # --config, --override, --dry-run
     add_common_logging_args(parser)  # --log-level, --log-file
     add_common_cleanup_args(parser)  # --eval-in, --eval-out, --trained-model
     args = parser.parse_args(argv)

--- a/src/pipeline/evaluate.py
+++ b/src/pipeline/evaluate.py
@@ -68,17 +68,17 @@ def make_parser_evaluate() -> argparse.ArgumentParser:
     """
     parser = argparse.ArgumentParser(description="Evaluate a trained classifier on a test set.")
     parser.add_argument("--image-size", type=int, 
-                        default=224, help="Square size used in preprocessing")
+                        default=None, help="Square size used in preprocessing")
     parser.add_argument("--model", 
                         choices=["resnet18","resnet34","resnet50"], 
-                        default="resnet18")
-    parser.add_argument("--batch-size", type=int, default=32)
-    parser.add_argument("--num-workers", type=int, default=4)
-    parser.add_argument("--seed", type=int, default=42)
+                        default=None)
+    parser.add_argument("--batch-size", type=int, default=None)
+    parser.add_argument("--num-workers", type=int, default=None)
+    parser.add_argument("--seed", type=int, default=None)
     parser.add_argument(
         "--mapping-path",
         type=Path,
-        default=OUTPUTS_DIR / "mappings" / "latest.json",
+        default=None,
         help="Path to index remap mapping JSON (default: OUTPUTS_DIR/mappings/latest.json)",
     )
     parser.add_argument(
@@ -100,7 +100,7 @@ def make_parser_evaluate() -> argparse.ArgumentParser:
     parser.add_argument("--mapping-pointer", type=Path, default=None,
                     help="Mapping pointer dir or file (preferred). Overrides --mapping-path/config.data.mapping_path.")
     
-    add_common_config_args(parser)   # --config, --override, --dry-run
+    add_common_config_args(parser, include_dry_run=True)   # --config, --override, --dry-run
     add_common_eval_args(parser)     # --eval-in, --eval-out, --trained-model
     add_common_logging_args(parser)  # --log-level, --log-file
     return parser
@@ -142,13 +142,13 @@ def main(argv=None):
     # ---- DRY RUN ----
     if dry:
         
-        eval_in = Path(cfg.data.eval_in) if cfg.data.eval_in else Path(args.eval_in)
-        mapping_path = Path(cfg.data.mapping_path) if cfg.data.mapping_path else Path(args.mapping_path)
-        weights_path = Path(cfg.model.weights_path) if cfg.model.weights_path else Path(args.trained_model)
+        eval_in      = Path(cfg.data.eval_in) if cfg.data.eval_in else (Path(args.eval_in) if args.eval_in else None)
+        mapping_path = Path(cfg.data.mapping_path) if cfg.data.mapping_path else (Path(args.mapping_path) if args.mapping_path else None)
+        weights_path = Path(cfg.model.weights_path) if cfg.model.weights_path else (Path(args.trained_model) if args.trained_model else None)
 
-        eval_exists = eval_in.exists()
-        mapping_exists = mapping_path.exists()
-        weights_exists = weights_path.exists()
+        eval_exists    = eval_in.exists() if eval_in else False
+        mapping_exists = mapping_path.exists() if mapping_path else False
+        weights_exists = weights_path.exists() if weights_path else False
 
         # tiny inline counter; no helpers, no image I/O
         per_class = {}

--- a/src/pipeline/evaluate.py
+++ b/src/pipeline/evaluate.py
@@ -39,7 +39,11 @@ from datetime import datetime, timezone
 import os as _os
 
 from src.utils.logging_utils import get_logger, configure_logging
-from src.utils.parser_utils import add_common_logging_args, add_common_eval_args
+from src.utils.parser_utils import (
+    add_common_logging_args, 
+    add_common_eval_args,
+    add_common_config_args,
+)
 from src.utils.paths import OUTPUTS_DIR
 
 from src.core.env import bootstrap_env, log_env_once
@@ -71,10 +75,6 @@ def make_parser_evaluate() -> argparse.ArgumentParser:
     parser.add_argument("--batch-size", type=int, default=32)
     parser.add_argument("--num-workers", type=int, default=4)
     parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--config", type=Path, default=None,
-                    help="Optional YAML config file for evaluation.")
-    parser.add_argument("--override", action="append", default=[],
-                        help="Override config values: key=val (e.g., io.top_per_class=8)")
     parser.add_argument(
         "--mapping-path",
         type=Path,
@@ -99,8 +99,8 @@ def make_parser_evaluate() -> argparse.ArgumentParser:
     )
     parser.add_argument("--mapping-pointer", type=Path, default=None,
                     help="Mapping pointer dir or file (preferred). Overrides --mapping-path/config.data.mapping_path.")
-    parser.add_argument("--dry-run", action="store_true",
-                        help="Plan only; no model loading, no metrics, no artifacts.") 
+    
+    add_common_config_args(parser)   # --config, --override, --dry-run
     add_common_eval_args(parser)     # --eval-in, --eval-out, --trained-model
     add_common_logging_args(parser)  # --log-level, --log-file
     return parser

--- a/src/pipeline/fetch.py
+++ b/src/pipeline/fetch.py
@@ -96,14 +96,8 @@ def make_parser_fetch_kaggle() -> argparse.ArgumentParser:
                         help="Skip writing outputs/downloads_pointer/.../latest.json")
     parser.add_argument("--pointer-dir", type=Path, default=None,
                         help="Override destination directory for pointer JSONs")
-    parser.add_argument("--config", type=Path, default=None,
-                    help="Optional YAML config file for fetch (config-first).")
-    parser.add_argument("--override", action="append", default=[],
-                        help="Override config values as key=val (e.g., dataset=owner/slug write_pointer=false). "
-                            "Repeat for multiple overrides.")
-    parser.add_argument("--dry-run", action="store_true", help="Plan only; do not download or write pointers.")
-    
-    add_common_config_args(parser)
+
+    add_common_config_args(parser)  # --config, --override, `--dry-run`
     add_common_logging_args(parser)  # --log-level, --log-file
     return parser
 

--- a/src/pipeline/fetch.py
+++ b/src/pipeline/fetch.py
@@ -66,7 +66,10 @@ import kagglehub
 
 from src.utils.paths import DEFAULT_DATASET
 from src.utils.logging_utils import configure_logging, get_logger
-from src.utils.parser_utils import add_common_logging_args
+from src.utils.parser_utils import (
+    add_common_logging_args, 
+    add_common_config_args,
+    )
 from src.utils.paths import DATA_DIR
 
 from src.core.config import build_fetch_config, to_dict
@@ -99,6 +102,8 @@ def make_parser_fetch_kaggle() -> argparse.ArgumentParser:
                         help="Override config values as key=val (e.g., dataset=owner/slug write_pointer=false). "
                             "Repeat for multiple overrides.")
     parser.add_argument("--dry-run", action="store_true", help="Plan only; do not download or write pointers.")
+    
+    add_common_config_args(parser)
     add_common_logging_args(parser)  # --log-level, --log-file
     return parser
 

--- a/src/pipeline/fetch.py
+++ b/src/pipeline/fetch.py
@@ -88,16 +88,16 @@ def make_parser_fetch_kaggle() -> argparse.ArgumentParser:
     python -m src.pipeline.fetch --cache-dir data --no-pointer
     """
     parser = argparse.ArgumentParser(description="Fetch Kaggle dataset with KaggleHub")
-    parser.add_argument("--dataset", type=str, default=DEFAULT_DATASET,
-                        help=f"Kaggle slug, e.g. 'owner/dataset' (default: {DEFAULT_DATASET})")
-    parser.add_argument("--cache-dir", type=Path, default=DATA_DIR,
+    parser.add_argument("--dataset", type=str, default=None,
+                        help="Kaggle slug, e.g. 'owner/dataset'")
+    parser.add_argument("--cache-dir", type=Path, default=None,
                         help="Directory to store the downloaded dataset (default: DATA_DIR)")
     parser.add_argument("--no-pointer", action="store_true",
                         help="Skip writing outputs/downloads_pointer/.../latest.json")
     parser.add_argument("--pointer-dir", type=Path, default=None,
                         help="Override destination directory for pointer JSONs")
 
-    add_common_config_args(parser)  # --config, --override, `--dry-run`
+    add_common_config_args(parser, include_dry_run=True)  # --config, --override, `--dry-run`
     add_common_logging_args(parser)  # --log-level, --log-file
     return parser
 
@@ -165,7 +165,7 @@ def main(argv=None) -> int:
     log.info("config.resolved", extra={"config": to_dict(cfg)})
 
     dataset = cfg.dataset or args.dataset
-    cache_dir = Path(cfg.cache_dir) if cfg.cache_dir else Path(args.cache_dir)
+    cache_dir = Path(cfg.cache_dir or args.cache_dir or DATA_DIR)
     write_pointer = bool(cfg.write_pointer)
     pointer_dir = cfg.pointer_dir or args.pointer_dir
 

--- a/src/pipeline/merge.py
+++ b/src/pipeline/merge.py
@@ -106,7 +106,7 @@ def _write_manifest(manifest: dict) -> Path:
 
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(description="Merge Kaggle Training/Testing into data/merged.")
-    parser.add_argument("--dataset", type=str, default=DEFAULT_DATASET,
+    parser.add_argument("--dataset", type=str, default=None,
                         help="Kaggle slug (owner/dataset) used to auto-locate the fetch pointer.")
     parser.add_argument("--pointer", type=Path, default=None,
                         help="Optional explicit path to the fetch pointer JSON (overrides --dataset).")

--- a/src/pipeline/merge.py
+++ b/src/pipeline/merge.py
@@ -25,7 +25,12 @@ from src.utils.paths import DATA_DIR, OUTPUTS_DIR, MERGED_DIR
 from src.core.config import build_merge_config, to_dict
 from src.utils.paths import DEFAULT_DATASET
 from src.utils.logging_utils import configure_logging, get_logger
-from src.utils.parser_utils import add_common_logging_args, add_exts_arg, parse_exts
+from src.utils.parser_utils import (
+    add_common_logging_args, 
+    add_exts_arg, 
+    parse_exts,
+    add_common_config_args,
+    )
 from src.core.artifacts import read_fetch_pointer
 
 log = get_logger(__name__)
@@ -105,13 +110,10 @@ def main(argv=None) -> int:
                         help="Kaggle slug (owner/dataset) used to auto-locate the fetch pointer.")
     parser.add_argument("--pointer", type=Path, default=None,
                         help="Optional explicit path to the fetch pointer JSON (overrides --dataset).")
-    parser.add_argument("--config", type=Path, default=None,
-                        help="Optional YAML config file for merge (config-first).")
-    parser.add_argument("--override", action="append", default=[],
-                        help="Override config values as key=val (e.g., clear_dest=true exts=all). Repeatable.")
     parser.add_argument("--clear-dest", action="store_true",
                         help="Delete all existing files/dirs in DATA_DIR/merged before writing.")
-    parser.add_argument("--dry-run", action="store_true", help="Plan only; do not write files.")
+    
+    add_common_config_args(parser)         # --config, --override, --dry-run
     add_common_logging_args(parser)        # --log-level, --log-file
     add_exts_arg(parser)                   # --exts with your '+webp' semantics
     args = parser.parse_args(argv)

--- a/src/pipeline/resize.py
+++ b/src/pipeline/resize.py
@@ -233,15 +233,15 @@ def main(argv=None) -> int:
     4) Processes images and prints a concise human summary to stdout.
     """
     parser = argparse.ArgumentParser(description="Resize/pad images to a canonical processed store (after merge/cleanup).")
-    parser.add_argument("--train-in",  type=Path, default=TRAIN_INPUT,
+    parser.add_argument("--train-in",  type=Path, default=None,
                         help="Input root (canonical): data/merged by default.")
-    parser.add_argument("--train-out", type=Path, default=TRAIN_OUT,
+    parser.add_argument("--train-out", type=Path, default=None,
                         help="Output root (canonical): data/processed by default.")
     parser.add_argument("--test-in",   type=Path, default=None,
                         help="(Optional) legacy testing input root; omitted in canonical flow.")
     parser.add_argument("--test-out",  type=Path, default=None,
                         help="(Optional) legacy testing output root; omitted in canonical flow.")
-    parser.add_argument("--size", type=int, default=224, help="Output square size in pixels (e.g., 224).")
+    parser.add_argument("--size", type=int, default=None, help="Output square size in pixels (e.g., 224).")
     
     add_common_config_args(parser)   # --config, --override
     add_common_logging_args(parser)  # --log-level, --log-file
@@ -256,8 +256,8 @@ def main(argv=None) -> int:
     cfg = build_resize_config(args.config, overrides=args.override)
     log.info("config.resolved", extra={"config": to_dict(cfg)})
 
-    train_in  = cfg.train_in  if cfg.train_in  is not None else args.train_in
-    train_out = cfg.train_out if cfg.train_out is not None else args.train_out
+    train_in  = (cfg.train_in  if cfg.train_in  is not None else args.train_in)  or MERGED_DIR
+    train_out = (cfg.train_out if cfg.train_out is not None else args.train_out) or PROCESSED_DIR
     test_in   = cfg.test_in   if cfg.test_in   is not None else args.test_in     # may be None
     test_out  = cfg.test_out  if cfg.test_out  is not None else args.test_out    # may be None
 

--- a/src/pipeline/resize.py
+++ b/src/pipeline/resize.py
@@ -63,7 +63,12 @@ import cv2
 import numpy as np
 
 from src.utils.logging_utils import configure_logging, get_logger
-from src.utils.parser_utils import add_common_logging_args, add_exts_arg, parse_exts
+from src.utils.parser_utils import (
+    add_common_logging_args, 
+    add_exts_arg, 
+    parse_exts,
+    add_common_config_args,
+    )
 from src.utils.paths import DATA_DIR, MERGED_DIR, PROCESSED_DIR
 
 from src.core.config import build_resize_config, to_dict
@@ -237,12 +242,8 @@ def main(argv=None) -> int:
     parser.add_argument("--test-out",  type=Path, default=None,
                         help="(Optional) legacy testing output root; omitted in canonical flow.")
     parser.add_argument("--size", type=int, default=224, help="Output square size in pixels (e.g., 224).")
-    parser.add_argument("--config", type=Path, default=None,
-                    help="Optional YAML config file for resize (config-first).")
-    parser.add_argument("--override", action="append", default=[],
-                        help="Override config values as key=val (e.g., size=256 exts=all). "
-                            "Repeat for multiple overrides.")
-    parser.add_argument("--dry-run", action="store_true", help="Plan only; do not split files/create dir.")
+    
+    add_common_config_args(parser)   # --config, --override
     add_common_logging_args(parser)  # --log-level, --log-file
     add_exts_arg(parser)             # --exts semantics (supports '+ext' and 'all')
     args = parser.parse_args(argv)

--- a/src/pipeline/split.py
+++ b/src/pipeline/split.py
@@ -34,7 +34,12 @@ from typing import Dict, List
 
 from src.utils.paths import DATA_DIR, DEFAULT_DATASET, PROCESSED_DIR
 from src.utils.logging_utils import configure_logging, get_logger
-from src.utils.parser_utils import add_common_logging_args, add_exts_arg, parse_exts
+from src.utils.parser_utils import (
+    add_common_logging_args, 
+    add_exts_arg, 
+    parse_exts, 
+    add_common_config_args
+    )
 
 from src.core.mapping import write_index_remap as mapping_write_index_remap, copy_index_remap
 from src.core.config import build_split_config
@@ -141,12 +146,8 @@ def main(argv=None) -> int:
     parser.add_argument("--clear-dest", action="store_true",
                         help="Delete existing data/{training,validation,testing} before writing.")
     add_exts_arg(parser)
+    add_common_config_args(parser)
     add_common_logging_args(parser)
-    parser.add_argument("--config", type=Path, default=None,
-                        help="Optional YAML config file for split (config-first).")
-    parser.add_argument("--override", action="append", default=[],
-                        help="Override config values as key=val. Repeatable.")
-    parser.add_argument("--dry-run", action="store_true")
 
     args = parser.parse_args(argv or [])
 

--- a/src/pipeline/split.py
+++ b/src/pipeline/split.py
@@ -134,15 +134,15 @@ def _write_index_and_pointer(
 
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(description="Split data/processed into train/val/test.")
-    parser.add_argument("--dataset", type=str, default=DEFAULT_DATASET,
+    parser.add_argument("--dataset", type=str, default=None,
                         help="Used only to label mapping pointers (owner/slug).")
-    parser.add_argument("--test-frac", type=float, default=0.20,
+    parser.add_argument("--test-frac", type=float, default=None,
                         help="Fraction per class for final test set (0-1).")
-    parser.add_argument("--val-frac", type=float, default=0.10,
+    parser.add_argument("--val-frac", type=float, default=None,
                         help="Fraction per class for validation set (0-1).")
-    parser.add_argument("--balance", choices=["none", "equalize"], default="none",
+    parser.add_argument("--balance", choices=["none", "equalize"], default=None,
                     help="none: keep original class sizes; equalize: cap each class to the smallest class before splitting.")
-    parser.add_argument("--seed", type=int, default=42, help="RNG seed.")
+    parser.add_argument("--seed", type=int, default=None, help="RNG seed.")
     parser.add_argument("--clear-dest", action="store_true",
                         help="Delete existing data/{training,validation,testing} before writing.")
     add_exts_arg(parser)
@@ -167,6 +167,12 @@ def main(argv=None) -> int:
     clear_dest = bool(getattr(cfg, "clear_dest", False) or getattr(args, "clear_dest", False))
 
     exts = parse_exts(args.exts)  # set[str] or empty set for "all"
+
+    # Guard: fractions must be provided by YAML or CLI
+    if test_frac is None or val_frac is None:
+        log.error("split.fracs_missing", extra={"test_frac": test_frac, "val_frac": val_frac})
+        print("❌ Missing fractions: please set data.test_frac and data.val_frac in YAML or via CLI.")
+        return 2
 
     if not (0.0 <= test_frac < 1.0 and 0.0 <= val_frac < 1.0 and test_frac + val_frac < 1.0):
         log.error("split.invalid_fracs", extra={"test_frac": test_frac, "val_frac": val_frac})

--- a/src/pipeline/train.py
+++ b/src/pipeline/train.py
@@ -65,6 +65,7 @@ from src.utils.parser_utils import (
     add_common_dataset_args,
     add_common_train_args,
     add_model_args,
+    add_common_config_args,
 )
 from src.train.runner import TrainRunnerInputs, run as run_training
 
@@ -93,20 +94,14 @@ def make_parser_train() -> argparse.ArgumentParser:
     add_common_train_args(parser)     # epochs, lr, weight_decay, scheduler, amp, etc.
     add_model_args(parser)            # model name + pretrained flag
     add_common_logging_args(parser)   # log level/file
+    # shared config flags: --config, --override, `--dry-run`
+    add_common_config_args(parser)
     parser.add_argument("--mapping-pointer", type=Path, default=None,
                     help="Mapping pointer dir or file (preferred). Overrides --index-remap/config.data.mapping_path.")
 
-    parser.add_argument("--config", type=Path, default=None,
-                    help="Optional YAML config file for training.")
-    parser.add_argument("--override", action="append", default=[],
-                        help="Override config values: key=val (e.g., model.name=resnet50)")
     parser.add_argument("--index-remap", type=Path, default=None,
     help="(Deprecated) Prefer config.data.mapping_path. If provided, overrides config.")
-    parser.add_argument(
-    "--dry-run",
-    action="store_true",
-    help="Plan only; do not start training or write checkpoints."
-)
+    
 
     return parser
 

--- a/src/pipeline/train.py
+++ b/src/pipeline/train.py
@@ -66,6 +66,7 @@ from src.utils.parser_utils import (
     add_common_train_args,
     add_model_args,
     add_common_config_args,
+    add_mapping_args,
 )
 from src.train.runner import TrainRunnerInputs, run as run_training
 
@@ -96,13 +97,9 @@ def make_parser_train() -> argparse.ArgumentParser:
     add_common_logging_args(parser)   # log level/file
     # shared config flags: --config, --override, `--dry-run`
     add_common_config_args(parser)
-    parser.add_argument("--mapping-pointer", type=Path, default=None,
-                    help="Mapping pointer dir or file (preferred). Overrides --index-remap/config.data.mapping_path.")
-
-    parser.add_argument("--index-remap", type=Path, default=None,
-    help="(Deprecated) Prefer config.data.mapping_path. If provided, overrides config.")
+    # Shared mapping flags: --mapping-pointer, --index-remap
+    add_mapping_args(parser)
     
-
     return parser
 
 

--- a/src/pipeline/train.py
+++ b/src/pipeline/train.py
@@ -89,7 +89,7 @@ def make_parser_train() -> argparse.ArgumentParser:
     python -m src.pipeline.train --train-in data/training_resized --test-in data/testing_resized
     """
     parser = argparse.ArgumentParser(description="Train a CNN on resized MRI images.")
-    parser.add_argument("--image-size", type=int, default=224,
+    parser.add_argument("--image-size", type=int, default=None,
                         help="Square size after resize/pad (must match your preprocessing)")
     add_common_dataset_args(parser)   # roots, batch size, workers, val_frac, seed, out dirs, etc.
     add_common_train_args(parser)     # epochs, lr, weight_decay, scheduler, amp, etc.

--- a/src/pipeline/validate.py
+++ b/src/pipeline/validate.py
@@ -51,7 +51,12 @@ from skimage.metrics import structural_similarity as ssim
 from datetime import datetime, timezone
 
 from src.utils.logging_utils import get_logger, configure_logging
-from src.utils.parser_utils import parse_exts, add_common_logging_args, DEFAULT_EXTS
+from src.utils.parser_utils import (
+    parse_exts, 
+    add_common_logging_args, 
+    add_common_config_args, 
+    DEFAULT_EXTS
+    )
 from src.utils.paths import DATA_DIR, OUTPUTS_DIR, MERGED_DIR, PROCESSED_DIR
 
 from src.core.mapping import read_index_remap, expected_classes_from_remap
@@ -560,15 +565,8 @@ def main(argv=None) -> int:
     action="store_false",
     help="Disable writing a JSON validation report to outputs/validation_reports/ (enabled by default).",
 )
-    parser.add_argument("--config", type=Path, default=None,
-                    help="Optional YAML config file for validate (config-first).")
-    parser.add_argument("--override", action="append", default=[],
-                        help="Override config values as key=val (e.g., size=256 exts=all fail_on=warning). "
-                            "Repeat for multiple overrides.")
     parser.add_argument("--mapping-pointer", type=Path, default=None,
                     help="Mapping pointer dir or file (preferred). If provided, overrides --index-remap.")
-    parser.add_argument("--dry-run", action="store_true",
-                        help="Plan only; do not open images or write a report.")
     # default ON
     parser.set_defaults(
         write_report=None,        
@@ -588,9 +586,9 @@ def main(argv=None) -> int:
     parser.add_argument("--ssim-thresh", type=float, default=None,
                     help="SSIM confirmation threshold for pHash near-duplicates (default: 0.90)")
 
-
-
-
+    
+    # shared config flags: --config, --override, `--dry-run`
+    add_common_config_args(parser)
     # shared logging flags: --log-level, --log-file
     add_common_logging_args(parser)
 

--- a/src/pipeline/validate.py
+++ b/src/pipeline/validate.py
@@ -54,7 +54,9 @@ from src.utils.logging_utils import get_logger, configure_logging
 from src.utils.parser_utils import (
     parse_exts, 
     add_common_logging_args, 
-    add_common_config_args, 
+    add_common_config_args,
+    add_dataset_args, 
+    add_mapping_args,
     DEFAULT_EXTS
     )
 from src.utils.paths import DATA_DIR, OUTPUTS_DIR, MERGED_DIR, PROCESSED_DIR
@@ -544,13 +546,6 @@ def main(argv=None) -> int:
     3) Run validation and apply `--fail-on` policy for exit code.
     """
     parser = argparse.ArgumentParser(description="Validate a dataset (pre or post processing)")
-    parser.add_argument("--in-dir", type=Path, default=None,
-        help="Dataset root to validate. If omitted: uses data/merged for pre or data/processed for post (based on config).")
-    parser.add_argument("--index-remap", type=Path, default=None,
-                    help="Optional path to index_remap.json (allowed classes). If omitted, label checks are skipped.")
-    parser.add_argument("--size", type=int, default=None, help="Expected image size (square)")
-    parser.add_argument("--exts", type=str, default=None,
-                        help="Comma-separated extensions. Use +ext to add; 'all' to accept any.")
     parser.add_argument("--dup-check", dest="dup_check", action="store_true", help="Enable duplicate detection")
     parser.add_argument("--no-dup-check", dest="dup_check", action="store_false", help="Disable duplicate detection")
     parser.add_argument("--warn-low-std", type=float, default=None,
@@ -565,8 +560,6 @@ def main(argv=None) -> int:
     action="store_false",
     help="Disable writing a JSON validation report to outputs/validation_reports/ (enabled by default).",
 )
-    parser.add_argument("--mapping-pointer", type=Path, default=None,
-                    help="Mapping pointer dir or file (preferred). If provided, overrides --index-remap.")
     # default ON
     parser.set_defaults(
         write_report=None,        
@@ -586,7 +579,10 @@ def main(argv=None) -> int:
     parser.add_argument("--ssim-thresh", type=float, default=None,
                     help="SSIM confirmation threshold for pHash near-duplicates (default: 0.90)")
 
-    
+    # shared mapping flags: --index-remap, --mapping-pointer
+    add_mapping_args(parser)
+    # shared dataset flags: --in-dir, --size, --exts
+    add_dataset_args(parser, with_size=True, with_exts=True)
     # shared config flags: --config, --override, `--dry-run`
     add_common_config_args(parser)
     # shared logging flags: --log-level, --log-file

--- a/src/utils/parser_utils.py
+++ b/src/utils/parser_utils.py
@@ -221,3 +221,40 @@ def add_common_config_args(
         parser.add_argument(
             "--dry-run", action="store_true", help=dry_help
         )
+
+
+def add_dataset_args(
+    parser: argparse.ArgumentParser,
+    *,
+    with_size: bool = True,
+    with_exts: bool = True,
+    default_size: int = None,
+    default_exts: str = None,
+) -> None:
+    """Attach common dataset I/O args (dirs, size, exts)."""
+    parser.add_argument(
+        "--in-dir", type=Path, default=None,
+        help="Dataset root to process. If omitted, uses stage-specific defaults."
+    )
+    if with_size:
+        parser.add_argument(
+            "--size", type=int, default=default_size,
+            help=f"Expected image size (square, default: {default_size})."
+        )
+    if with_exts:
+        parser.add_argument(
+            "--exts", type=str, default=default_exts,
+            help="Comma-separated extensions. Use +ext to add; 'all' to accept any."
+        )
+
+
+def add_mapping_args(parser: argparse.ArgumentParser) -> None:
+    """Attach common mapping/index args used in validate/evaluate/train."""
+    parser.add_argument(
+        "--index-remap", type=Path, default=None,
+        help="Optional path to index_remap.json (allowed classes)."
+    )
+    parser.add_argument(
+        "--mapping-pointer", type=Path, default=None,
+        help="Pointer dir/file for latest mapping; overrides --index-remap."
+    )

--- a/src/utils/parser_utils.py
+++ b/src/utils/parser_utils.py
@@ -51,7 +51,7 @@ def add_common_logging_args(parser: argparse.ArgumentParser) -> None:
     """Attach standard logging args to any parser."""
     parser.add_argument(
         "--log-level",
-        default="INFO",
+        default=None,
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
         help="Logging verbosity",
     )
@@ -71,7 +71,7 @@ def add_exts_arg(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--exts",
         type=str,
-        default=DEFAULT_EXTS,  # ← use the constant
+        default=None,  # ← use the constant
         help=(
             "Comma-separated extensions (lowercased). "
             "Use +ext to add to defaults, e.g. '+webp,+gif'. "
@@ -119,47 +119,47 @@ def parse_exts(exts) -> set[str]:
 
 
 def add_common_train_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-    parser.add_argument("--batch-size", type=int, default=32)
-    parser.add_argument("--num-workers", type=int, default=4)
+    parser.add_argument("--batch-size", type=int, default=None)
+    parser.add_argument("--num-workers", type=int, default=None)
     parser.add_argument("--epochs", type=int, default=None,
                         help="(Deprecated) Prefer config.loop.epochs. If provided, overrides config.")
-    parser.add_argument("--lr", type=float, default=1e-4)
-    parser.add_argument("--weight-decay", type=float, default=1e-4)
-    parser.add_argument("--step-size", type=int, default=5, help="StepLR: step_size (epochs)")
-    parser.add_argument("--gamma", type=float, default=0.5, help="StepLR: gamma")
-    parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--no-amp", dest="amp", action="store_false", default=True,
+    parser.add_argument("--lr", type=float, default=None)
+    parser.add_argument("--weight-decay", type=float, default=None)
+    parser.add_argument("--step-size", type=int, default=None, help="StepLR: step_size (epochs)")
+    parser.add_argument("--gamma", type=float, default=None, help="StepLR: gamma")
+    parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument("--no-amp", dest="amp", action="store_false", default=None,
                         help="Disable automatic mixed precision (AMP)")
     return parser
 
 
 def add_model_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-    parser.add_argument("--model", choices=["resnet18", "resnet34", "resnet50"], default="resnet18")
-    parser.add_argument("--pretrained", action="store_true", default=True,
+    parser.add_argument("--model", choices=["resnet18", "resnet34", "resnet50"], default=None)
+    parser.add_argument("--pretrained", action="store_true", default=None,
                         help="Use ImageNet pretrained weights (opt-in)")
-    parser.add_argument("--out-models", type=Path, default=MODELS_DIR,
+    parser.add_argument("--out-models", type=Path, default=None,
                         help="Directory to save best weights (default: models/)")
-    parser.add_argument("--out-summary", type=Path, default=OUTPUTS_DIR / "training",
+    parser.add_argument("--out-summary", type=Path, default=None,
                         help="Directory to save training_summary.json (default: outputs/training/)")
     return parser
 
 
 def add_common_dataset_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-    parser.add_argument("--train-in", type=Path, default=DATA_DIR / "training",
+    parser.add_argument("--train-in", type=Path, default=None,
                     help="Input root with class subfolders for TRAIN (default: data/training)")
-    parser.add_argument("--test-in", type=Path, default=DATA_DIR / "testing",
+    parser.add_argument("--test-in", type=Path, default=None,
                     help="Optional input root with class subfolders for TEST (default: data/testing)")
     parser.add_argument("--original-test-in", type=Path, default=None,
                         help="Optional 'original' external test set root (class subfolders)")
-    parser.add_argument("--val-frac", type=float, default=0.20,
+    parser.add_argument("--val-frac", type=float, default=None,
                         help="Validation fraction taken from --train-in (stratified)")
     return parser
 
 
 def add_common_eval_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-    parser.add_argument("--eval-in", type=Path, default=DATA_DIR / "testing",
+    parser.add_argument("--eval-in", type=Path, default=None,
                     help="Input root with class subfolders for evaluation (default: data/testing)")
-    parser.add_argument("--eval-out", type=Path, default=OUTPUTS_DIR / "evaluation",
+    parser.add_argument("--eval-out", type=Path, default=None,
                         help="Output directory for evaluation (default: outputs/evaluation)")
     parser.add_argument("--trained-model", type=Path)
     return parser
@@ -173,19 +173,19 @@ def add_common_cleanup_args(parser: argparse.ArgumentParser) -> argparse.Argumen
     parser.add_argument(
         "--report",
         type=str,
-        default="latest",
+        default=None,
         help="Path to a validation report JSON, or 'latest' to use most recent under outputs/validation_reports.",
     )
     parser.add_argument(
         "--policy",
         choices=["strict", "within_class", "report_only"],
-        default=DEFAULT_POLICY,
+        default=None,
         help="Quarantine policy.",
     )
     parser.add_argument(
         "--why",
         choices=["errors", "warnings", "both"],
-        default=DEFAULT_ACT_ON,
+        default=None,
         help="Which severities to act on.",
     )
     parser.add_argument(

--- a/src/utils/parser_utils.py
+++ b/src/utils/parser_utils.py
@@ -200,3 +200,24 @@ def add_common_cleanup_args(parser: argparse.ArgumentParser) -> argparse.Argumen
         help="If --report=latest, prefer a validation report tagged with this suffix (e.g., *_pre.json).",
     )
     return parser
+
+
+def add_common_config_args(
+    parser: argparse.ArgumentParser,
+    *,
+    include_dry_run: bool = False,
+    dry_help: str = "Plan only; do not execute or write artifacts."
+) -> None:
+    """Attach config/override (and optional --dry-run) flags to any parser."""
+    parser.add_argument(
+        "--config", type=Path, default=None,
+        help="Optional YAML config file (config-first)."
+    )
+    parser.add_argument(
+        "--override", "-o", action="append", default=[],
+        help="Override config values as key=val. Repeatable."
+    )
+    if include_dry_run:
+        parser.add_argument(
+            "--dry-run", action="store_true", help=dry_help
+        )


### PR DESCRIPTION
## 🔄 Pull Request: Tie Parser into All Pipeline Stages

### Summary
This PR integrates the common parser across all pipeline stages, ensuring consistent CLI argument handling and configuration management throughout the workflow.

### Changes
- Added `add_common_config_args` usage to each stage parser.
- Updated stage modules (`fetch`, `merge`, `validate`, `resize`, `split`, `train`, `evaluate`, etc.) to support the shared parser.
- Standardized default values and flag behavior across the pipeline.
- Improved maintainability by centralizing argument definitions.

### Benefits
- Consistent interface for all pipeline stages.
- Reduced duplication of argument parsing logic.
- Easier future extensions and modifications to CLI options.
- Cleaner, more predictable workflows for users.

### Next Steps
- Extend test coverage to validate argument handling for each stage.
- Document available CLI flags in the README.
