### PR TITLE
Refactor/config-tidy

### DIFF
--- a/src/configs/pipeline.yaml
+++ b/src/configs/pipeline.yaml
@@ -86,7 +86,7 @@ train:
     image_size: 224
     batch_size: 32
     num_workers: 4
-    val_in: data/validation      # <<< add this
+  val_in: data/validation      
   aug:
     rotate_deg: 15
     hflip_prob: 0.5
@@ -134,6 +134,7 @@ train:
   dry_run: false
 evaluate:
   data:
+    mapping_path: outputs/mappings/latest.json 
     image_size: 224
     eval_in: data/testing        
     batch_size: 32

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -591,9 +591,8 @@ def build_train_config(yaml_path: Optional[Path], overrides: List[str]) -> Train
     if isinstance(out_summary, str):
         io_block["out_summary"] = Path(out_summary)
     
-    val_in_path = base.get("val_in")
-    if isinstance(val_in_path, str):
-        base["val_in"] = Path(val_in_path)
+    val_in_raw = base.get("val_in")
+    val_in = Path(val_in_raw) if isinstance(val_in_raw, str) else val_in_raw
 
     return TrainConfig(
         data=DataConfig(**base.get("data", {})),
@@ -605,7 +604,7 @@ def build_train_config(yaml_path: Optional[Path], overrides: List[str]) -> Train
         callbacks=callbacks,
         run_id=base.get("run_id"),
         dry_run=bool(base.get("dry_run", False)),
-        val_in=val_in_path if val_in_path else None,
+        val_in=val_in,
     )
 
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -24,6 +24,23 @@ import yaml
 
 from src.utils.paths import CONFIGS_DIR
 
+@dataclass
+class LoggingConfig:
+    """
+    Logging defaults applied by the orchestrator.
+
+    level : str
+        Log level (e.g., 'INFO', 'DEBUG').
+    file : Optional[str]
+        Optional fixed log file path. If None, each stage decides (your code
+        already supports auto/fixed in configure_logging()).
+    json : bool
+        Future toggle for JSON logs if JSON formatter is added.
+    """
+    level: str = "INFO"
+    file: Optional[str] = None
+    json: bool = False
+
 # ----------------------- Stage Configs ---------------------------
 
 ### Fetch Config
@@ -49,6 +66,7 @@ class FetchConfig:
     write_pointer: bool = True
     pointer_dir: Optional[Path] = None
     dry_run: bool = False  # for testing
+    log: LoggingConfig = field(default_factory=LoggingConfig)
 
 def build_fetch_config(yaml_path: Optional[Path], overrides: List[str]) -> FetchConfig:
     """
@@ -61,6 +79,17 @@ def build_fetch_config(yaml_path: Optional[Path], overrides: List[str]) -> Fetch
         yaml_cfg = load_yaml_config(yaml_path)
         _deep_update(base, yaml_cfg)
     base = apply_overrides(base, overrides)
+
+    #  ---- Back-compat for flat fields ----
+    if "log_level" in base and "log" not in base:
+        base.setdefault("log", {})
+        base["log"]["level"] = base.pop("log_level") or base["log"].get("level", "INFO")
+    if "log_file" in base and "log" not in base:
+        base.setdefault("log", {})
+        base["log"]["file"] = base.pop("log_file") or base["log"].get("file")
+    
+    log_block = base.get("log", {}) or {}
+
     # Normalize Path-like fields
     cache_dir = Path(base["cache_dir"]) if base.get("cache_dir") else None
     pointer_dir = Path(base["pointer_dir"]) if base.get("pointer_dir") else None
@@ -70,6 +99,7 @@ def build_fetch_config(yaml_path: Optional[Path], overrides: List[str]) -> Fetch
         write_pointer=bool(base.get("write_pointer", True)),
         pointer_dir=pointer_dir,
         dry_run=bool(base.get("dry_run", False)),
+        log=LoggingConfig(**log_block),
     )
 
 
@@ -94,6 +124,7 @@ class MergeConfig:
     exts: Optional[object] = None
     clear_dest: bool = False
     dry_run: bool = False  # for testing
+    log: LoggingConfig = field(default_factory=LoggingConfig)
 
 def build_merge_config(yaml_path: Optional[Path], overrides: List[str]) -> MergeConfig:
     """
@@ -113,6 +144,16 @@ def build_merge_config(yaml_path: Optional[Path], overrides: List[str]) -> Merge
         _deep_update(base, yaml_cfg)
     base = apply_overrides(base, overrides)
 
+    #  ---- Back-compat for flat fields ----
+    if "log_level" in base and "log" not in base:
+        base.setdefault("log", {})
+        base["log"]["level"] = base.pop("log_level") or base["log"].get("level", "INFO")
+    if "log_file" in base and "log" not in base:
+        base.setdefault("log", {})
+        base["log"]["file"] = base.pop("log_file") or base["log"].get("file")
+    
+    log_block = base.get("log", {}) or {}
+
     pointer = Path(base["pointer"]) if base.get("pointer") else None
     return MergeConfig(
         dataset=base.get("dataset"),
@@ -120,6 +161,7 @@ def build_merge_config(yaml_path: Optional[Path], overrides: List[str]) -> Merge
         exts=base.get("exts"),
         clear_dest=bool(base.get("clear_dest", False)),
         dry_run=bool(base.get("dry_run", False)),
+        log=LoggingConfig(**log_block),
     )
 
 ### Validate Config
@@ -166,6 +208,7 @@ class ValidateConfig:
     report_tag: Optional[str] = None  # "pre" | "post" | None
     # How to detect duplicates: "file" (bytes), "content" (RGB+resize), or "both"
     dup_mode: str = "file"
+    log: LoggingConfig = field(default_factory=LoggingConfig)
 
 def build_validate_config(yaml_path: Optional[Path], overrides: List[str]) -> ValidateConfig:
     """
@@ -191,6 +234,7 @@ def build_validate_config(yaml_path: Optional[Path], overrides: List[str]) -> Va
         "require_rgb": True,
         "report_tag": None,
         "dup_mode": "file",           # "file" | "content" | "both"
+        "log": {"level": "INFO", "file": None, "json": False},
     }
 
     if yaml_path:
@@ -199,6 +243,16 @@ def build_validate_config(yaml_path: Optional[Path], overrides: List[str]) -> Va
     base = apply_overrides(base, overrides)
 
     def _p(x): return Path(x) if x is not None else None
+
+    #  ---- Back-compat for flat fields ----
+    if "log_level" in base and "log" not in base:
+        base.setdefault("log", {})
+        base["log"]["level"] = base.pop("log_level") or base["log"].get("level", "INFO")
+    if "log_file" in base and "log" not in base:
+        base.setdefault("log", {})
+        base["log"]["file"] = base.pop("log_file") or base["log"].get("file")
+    
+    log_block = base.get("log", {}) or {}
 
     return ValidateConfig(
         in_dir=_p(base.get("in_dir")),
@@ -219,6 +273,7 @@ def build_validate_config(yaml_path: Optional[Path], overrides: List[str]) -> Va
         require_rgb=bool(base.get("require_rgb", True)),
         report_tag=base.get("report_tag"),
         dup_mode=str(base.get("dup_mode", "file")),
+        log=LoggingConfig(**log_block), 
     )
 
 
@@ -230,8 +285,7 @@ class CleanupConfig:
     policy: str = "strict"       # strict | within_class | report_only
     why: str = "errors"          # errors | warnings | both
     dry_run: bool = False
-    log_level: str = "INFO"
-    log_file: Optional[str] = None
+    log: LoggingConfig = field(default_factory=LoggingConfig)
     report_tag: Optional[str] = None
 
 def build_cleanup_config(config_file: Path | None, overrides: list[str] | None = None) -> CleanupConfig:
@@ -247,15 +301,24 @@ def build_cleanup_config(config_file: Path | None, overrides: list[str] | None =
 
     base = apply_overrides(base, overrides or [])
 
+    #  ---- Back-compat for flat fields ----
+    if "log_level" in base and "log" not in base:
+        base.setdefault("log", {})
+        base["log"]["level"] = base.pop("log_level") or base["log"].get("level", "INFO")
+    if "log_file" in base and "log" not in base:
+        base.setdefault("log", {})
+        base["log"]["file"] = base.pop("log_file") or base["log"].get("file")
+    
+    log_block = base.get("log", {}) or {}
+
     return CleanupConfig(
         stage=str(base.get("stage", "cleanup")),
         report=str(base.get("report", "latest")),
         policy=str(base.get("policy", "strict")),
         why=str(base.get("why", "errors")),
         dry_run=bool(base.get("dry_run", False)),
-        log_level=str(base.get("log_level", "INFO")),
-        log_file=base.get("log_file"),
         report_tag=base.get("report_tag"),
+        log=LoggingConfig(**log_block),
     )
 
 
@@ -282,6 +345,7 @@ class ResizeConfig:
     size: int = 224
     exts: Optional[object] = None  # list[str] | 'all' | None
     dry_run: bool = False  # for testing
+    log: LoggingConfig = field(default_factory=LoggingConfig)
 
 def build_resize_config(yaml_path: Optional[Path], overrides: List[str]) -> ResizeConfig:
     """
@@ -309,6 +373,16 @@ def build_resize_config(yaml_path: Optional[Path], overrides: List[str]) -> Resi
         parts = [e.strip() for e in exts_val.split(",") if e.strip()]
         exts_val = [p if p.startswith(".") else f".{p}" for p in parts]
 
+    #  ---- Back-compat for flat fields ----
+    if "log_level" in base and "log" not in base:
+        base.setdefault("log", {})
+        base["log"]["level"] = base.pop("log_level") or base["log"].get("level", "INFO")
+    if "log_file" in base and "log" not in base:
+        base.setdefault("log", {})
+        base["log"]["file"] = base.pop("log_file") or base["log"].get("file")
+    
+    log_block = base.get("log", {}) or {}
+
     return ResizeConfig(
         train_in=_p(base.get("train_in")),
         train_out=_p(base.get("train_out")),
@@ -317,6 +391,7 @@ def build_resize_config(yaml_path: Optional[Path], overrides: List[str]) -> Resi
         size=int(base.get("size", 224)),
         exts=exts_val,  
         dry_run=bool(base.get("dry_run", False)),
+        log=LoggingConfig(**log_block),
     )
 
 
@@ -358,6 +433,7 @@ class SplitConfig:
     mapping_write_split_copy: bool = False
     dry_run: bool = False  # for testing
     val_frac: float = 0.10
+    log: LoggingConfig = field(default_factory=LoggingConfig)
 
 def build_split_config(yaml_path: Optional[Path], overrides: List[str]) -> SplitConfig:
     """
@@ -390,6 +466,16 @@ def build_split_config(yaml_path: Optional[Path], overrides: List[str]) -> Split
     if isinstance(exts_val, str) and exts_val.lower() != "all":
         parts = [e.strip() for e in exts_val.split(",") if e.strip()]
         exts_val = [p if p.startswith(".") else f".{p}" for p in parts]
+    
+    #  ---- Back-compat for flat fields ----
+    if "log_level" in base and "log" not in base:
+        base.setdefault("log", {})
+        base["log"]["level"] = base.pop("log_level") or base["log"].get("level", "INFO")
+    if "log_file" in base and "log" not in base:
+        base.setdefault("log", {})
+        base["log"]["file"] = base.pop("log_file") or base["log"].get("file")
+    
+    log_block = base.get("log", {}) or {}
 
     return SplitConfig(
         dataset=base.get("dataset"),
@@ -403,6 +489,7 @@ def build_split_config(yaml_path: Optional[Path], overrides: List[str]) -> Split
         mapping_use_dataset_subdir=bool(base.get("mapping_use_dataset_subdir", False)),
         mapping_write_split_copy=bool(base.get("mapping_write_split_copy", False)),
         dry_run=bool(base.get("dry_run", False)),
+        log=LoggingConfig(**log_block),
     )
 
 
@@ -561,6 +648,7 @@ class TrainConfig:
     run_id: Optional[str] = None
     dry_run: bool = False
     val_in: Optional[Path] = None
+    log: LoggingConfig = field(default_factory=LoggingConfig)
 
 def build_train_config(yaml_path: Optional[Path], overrides: List[str]) -> TrainConfig:
     """
@@ -594,6 +682,16 @@ def build_train_config(yaml_path: Optional[Path], overrides: List[str]) -> Train
     val_in_raw = base.get("val_in")
     val_in = Path(val_in_raw) if isinstance(val_in_raw, str) else val_in_raw
 
+    #  ---- Back-compat for flat fields ----
+    if "log_level" in base and "log" not in base:
+        base.setdefault("log", {})
+        base["log"]["level"] = base.pop("log_level") or base["log"].get("level", "INFO")
+    if "log_file" in base and "log" not in base:
+        base.setdefault("log", {})
+        base["log"]["file"] = base.pop("log_file") or base["log"].get("file")
+    
+    log_block = base.get("log", {}) or {}
+
     return TrainConfig(
         data=DataConfig(**base.get("data", {})),
         model=ModelConfig(**base.get("model", {})),
@@ -601,6 +699,7 @@ def build_train_config(yaml_path: Optional[Path], overrides: List[str]) -> Train
         io=TrainIOConfig(**io_block),
         loop=TrainLoopConfig(**base.get("loop", {})),
         aug=AugmentConfig(**base.get("aug", {})),
+        log=LoggingConfig(**log_block),
         callbacks=callbacks,
         run_id=base.get("run_id"),
         dry_run=bool(base.get("dry_run", False)),
@@ -616,6 +715,8 @@ class EvalConfig:
     io: EvalIOConfig = field(default_factory=EvalIOConfig)
     run_id: Optional[str] = None
     dry_run: bool = False
+    log: LoggingConfig = field(default_factory=LoggingConfig)
+
 
 def build_eval_config(yaml_path: Optional[Path], overrides: List[str]) -> EvalConfig:
     """
@@ -649,6 +750,16 @@ def build_eval_config(yaml_path: Optional[Path], overrides: List[str]) -> EvalCo
     mptr = data_block.get("mapping_pointer")
     if isinstance(mptr, str):
         data_block["mapping_pointer"] = Path(mptr)
+    
+    #  ---- Back-compat for flat fields ----
+    if "log_level" in base and "log" not in base:
+        base.setdefault("log", {})
+        base["log"]["level"] = base.pop("log_level") or base["log"].get("level", "INFO")
+    if "log_file" in base and "log" not in base:
+        base.setdefault("log", {})
+        base["log"]["file"] = base.pop("log_file") or base["log"].get("file")
+    
+    log_block = base.get("log", {}) or {}
 
     return EvalConfig(
         data=DataConfig(**data_block),
@@ -656,6 +767,7 @@ def build_eval_config(yaml_path: Optional[Path], overrides: List[str]) -> EvalCo
         io=EvalIOConfig(**io_block),
         run_id=base.get("run_id"),
         dry_run=bool(base.get("dry_run", False)),
+        log=LoggingConfig(**log_block),
     )
 
 
@@ -677,24 +789,6 @@ class EnvConfig:
     prefer_cuda: bool = True
     cudnn_deterministic: bool = True
     cudnn_benchmark: bool = False
-
-
-@dataclass
-class LoggingConfig:
-    """
-    Logging defaults applied by the orchestrator.
-
-    level : str
-        Log level (e.g., 'INFO', 'DEBUG').
-    file : Optional[str]
-        Optional fixed log file path. If None, each stage decides (your code
-        already supports auto/fixed in configure_logging()).
-    json : bool
-        Future toggle for JSON logs if you add a JSON formatter.
-    """
-    level: str = "INFO"
-    file: Optional[str] = None
-    json: bool = False
 
 
 @dataclass

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -560,6 +560,7 @@ class TrainConfig:
     callbacks: CallbacksConfig = field(default_factory=CallbacksConfig)
     run_id: Optional[str] = None
     dry_run: bool = False
+    val_in: Optional[Path] = None
 
 def build_train_config(yaml_path: Optional[Path], overrides: List[str]) -> TrainConfig:
     """
@@ -589,6 +590,10 @@ def build_train_config(yaml_path: Optional[Path], overrides: List[str]) -> Train
         io_block["out_models"] = Path(out_models)
     if isinstance(out_summary, str):
         io_block["out_summary"] = Path(out_summary)
+    
+    val_in_path = base.get("val_in")
+    if isinstance(val_in_path, str):
+        base["val_in"] = Path(val_in_path)
 
     return TrainConfig(
         data=DataConfig(**base.get("data", {})),
@@ -600,6 +605,7 @@ def build_train_config(yaml_path: Optional[Path], overrides: List[str]) -> Train
         callbacks=callbacks,
         run_id=base.get("run_id"),
         dry_run=bool(base.get("dry_run", False)),
+        val_in=val_in_path if val_in_path else None,
     )
 
 

--- a/src/pipeline/cleanup.py
+++ b/src/pipeline/cleanup.py
@@ -217,16 +217,7 @@ def main(argv=None) -> int:
     add_common_cleanup_args(parser)  # --eval-in, --eval-out, --trained-model
     args = parser.parse_args(argv)
 
-    # Run-aware logging
-    run_id = os.getenv("RUN_ID") or _now_run_id()
 
-    if args.log_file:
-        configure_logging(log_level=args.log_level, file_mode="fixed",
-                          log_file=args.log_file, run_id=run_id, stage="cleanup")
-    else:
-        configure_logging(log_level=args.log_level, file_mode="auto",
-                          run_id=run_id, stage="cleanup")
-        
     cfg = None
     try:
         from src.core.config import build_cleanup_config, to_dict
@@ -234,6 +225,19 @@ def main(argv=None) -> int:
         log.info("config.resolved", extra={"config": to_dict(cfg)})
     except Exception:
         cfg = None  # fallback: no structured config available
+
+    # Run-aware logging
+    run_id = os.getenv("RUN_ID") or _now_run_id()
+    log_level = cfg.log_level or args.log_level or "INFO"
+    log_file  = cfg.log_file or args.log_file or None
+
+    configure_logging(
+        log_level=log_level,
+        file_mode="fixed" if log_file else "auto",
+        log_file=log_file,
+        run_id=run_id,
+        stage="cleanup",
+    )
 
     # Merge config → args (config wins when present)
     report  = getattr(cfg, "report", None)  or args.report

--- a/src/pipeline/cleanup.py
+++ b/src/pipeline/cleanup.py
@@ -227,8 +227,8 @@ def main(argv=None) -> int:
 
     # Run-aware logging
     run_id = os.getenv("RUN_ID") or _now_run_id()
-    log_level = cfg.log_level or args.log_level or "INFO"
-    log_file  = cfg.log_file or args.log_file or None
+    log_level = (getattr(cfg.log, "level", None) or args.log_level or "INFO")
+    log_file  = (getattr(cfg.log, "file",  None) or args.log_file  or None)
 
     configure_logging(
         log_level=log_level,

--- a/src/pipeline/cleanup.py
+++ b/src/pipeline/cleanup.py
@@ -219,8 +219,14 @@ def main(argv=None) -> int:
 
     # Run-aware logging
     run_id = os.getenv("RUN_ID") or _now_run_id()
-    configure_logging(log_level=args.log_level, log_file=args.log_file, run_id=run_id, stage="cleanup")
 
+    if args.log_file:
+        configure_logging(log_level=args.log_level, file_mode="fixed",
+                          log_file=args.log_file, run_id=run_id, stage="cleanup")
+    else:
+        configure_logging(log_level=args.log_level, file_mode="auto",
+                          run_id=run_id, stage="cleanup")
+        
     cfg = None
     try:
         from src.core.config import build_cleanup_config, to_dict

--- a/src/pipeline/cleanup.py
+++ b/src/pipeline/cleanup.py
@@ -222,7 +222,6 @@ def main(argv=None) -> int:
     try:
         from src.core.config import build_cleanup_config, to_dict
         cfg = build_cleanup_config(args.config, overrides=args.override)
-        log.info("config.resolved", extra={"config": to_dict(cfg)})
     except Exception:
         cfg = None  # fallback: no structured config available
 
@@ -238,6 +237,7 @@ def main(argv=None) -> int:
         run_id=run_id,
         stage="cleanup",
     )
+    log.info("config.resolved", extra={"config": to_dict(cfg)})
 
     # Merge config → args (config wins when present)
     report  = getattr(cfg, "report", None)  or args.report

--- a/src/pipeline/evaluate.py
+++ b/src/pipeline/evaluate.py
@@ -121,8 +121,8 @@ def main(argv=None):
 
     # 2) Configure logging with run_id + stage='evaluate'
     run_id = _os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
-    log_level = cfg.log_level or args.log_level or "INFO"
-    log_file  = cfg.log_file or args.log_file or None
+    log_level = (getattr(cfg.log, "level", None) or args.log_level or "INFO")
+    log_file  = (getattr(cfg.log, "file",  None) or args.log_file  or None)
 
     configure_logging(
         log_level=log_level,

--- a/src/pipeline/evaluate.py
+++ b/src/pipeline/evaluate.py
@@ -118,7 +118,6 @@ def main(argv=None):
     args = parser.parse_args(argv)
 
     cfg = build_eval_config(args.config, overrides=args.override)
-    log.info("config.resolved", extra={"config": to_dict(cfg)})
 
     # 2) Configure logging with run_id + stage='evaluate'
     run_id = _os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
@@ -132,6 +131,7 @@ def main(argv=None):
         run_id=run_id,
         stage="evaluate",
     )
+    log.info("config.resolved", extra={"config": to_dict(cfg)})
     log.info("evaluate.cli_start", extra={
         "cli_args": {k: (str(v) if isinstance(v, Path) else v) for k, v in vars(args).items()}
     })

--- a/src/pipeline/evaluate.py
+++ b/src/pipeline/evaluate.py
@@ -117,22 +117,27 @@ def main(argv=None):
     parser = make_parser_evaluate()
     args = parser.parse_args(argv)
 
+    cfg = build_eval_config(args.config, overrides=args.override)
+    log.info("config.resolved", extra={"config": to_dict(cfg)})
+
     # 2) Configure logging with run_id + stage='evaluate'
     run_id = _os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
-    if args.log_file:
-        configure_logging(log_level=args.log_level, file_mode="fixed", log_file=args.log_file, run_id=run_id, stage="evaluate")
-    else:
-        configure_logging(log_level=args.log_level, file_mode="auto", run_id=run_id, stage="evaluate")
-    
+    log_level = cfg.log_level or args.log_level or "INFO"
+    log_file  = cfg.log_file or args.log_file or None
+
+    configure_logging(
+        log_level=log_level,
+        file_mode="fixed" if log_file else "auto",
+        log_file=log_file,
+        run_id=run_id,
+        stage="evaluate",
+    )
     log.info("evaluate.cli_start", extra={
         "cli_args": {k: (str(v) if isinstance(v, Path) else v) for k, v in vars(args).items()}
     })
 
     bootstrap_env(seed=args.seed)
     log_env_once()
-
-    cfg = build_eval_config(args.config, overrides=args.override)
-    log.info("config.resolved", extra={"config": to_dict(cfg)})
 
     mapping_pointer = getattr(cfg.data, "mapping_pointer", None) or getattr(args, "mapping_pointer", None)
     mapping_path = cfg.data.mapping_path or args.mapping_path

--- a/src/pipeline/fetch.py
+++ b/src/pipeline/fetch.py
@@ -155,7 +155,6 @@ def main(argv=None) -> int:
 
     # Resolve config (config-first with CLI fallback)
     cfg = build_fetch_config(args.config, overrides=args.override)
-    log.info("config.resolved", extra={"config": to_dict(cfg)})
 
     # Run-aware logging (ties logs across stages)
     run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
@@ -169,6 +168,7 @@ def main(argv=None) -> int:
         run_id=run_id,
         stage="fetch",
     )
+    log.info("config.resolved", extra={"config": to_dict(cfg)})
 
     dataset = cfg.dataset or args.dataset
     cache_dir = Path(cfg.cache_dir or args.cache_dir or DATA_DIR)

--- a/src/pipeline/fetch.py
+++ b/src/pipeline/fetch.py
@@ -153,16 +153,22 @@ def main(argv=None) -> int:
     parser = make_parser_fetch_kaggle()
     args = parser.parse_args(argv)
 
-    # Run-aware logging (ties logs across stages)
-    run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
-    if args.log_file:
-        configure_logging(log_level=args.log_level, file_mode="fixed", log_file=args.log_file, run_id=run_id, stage="fetch")
-    else:
-        configure_logging(log_level=args.log_level, file_mode="auto", run_id=run_id, stage="fetch")
-
     # Resolve config (config-first with CLI fallback)
     cfg = build_fetch_config(args.config, overrides=args.override)
     log.info("config.resolved", extra={"config": to_dict(cfg)})
+
+    # Run-aware logging (ties logs across stages)
+    run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
+    log_level = cfg.log_level or args.log_level or "INFO"
+    log_file  = cfg.log_file or args.log_file or None
+
+    configure_logging(
+        log_level=log_level,
+        file_mode="fixed" if log_file else "auto",
+        log_file=log_file,
+        run_id=run_id,
+        stage="fetch",
+    )
 
     dataset = cfg.dataset or args.dataset
     cache_dir = Path(cfg.cache_dir or args.cache_dir or DATA_DIR)

--- a/src/pipeline/fetch.py
+++ b/src/pipeline/fetch.py
@@ -158,8 +158,8 @@ def main(argv=None) -> int:
 
     # Run-aware logging (ties logs across stages)
     run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
-    log_level = cfg.log_level or args.log_level or "INFO"
-    log_file  = cfg.log_file or args.log_file or None
+    log_level = (getattr(cfg.log, "level", None) or args.log_level or "INFO")
+    log_file  = (getattr(cfg.log, "file",  None) or args.log_file  or None)
 
     configure_logging(
         log_level=log_level,

--- a/src/pipeline/merge.py
+++ b/src/pipeline/merge.py
@@ -118,17 +118,23 @@ def main(argv=None) -> int:
     add_exts_arg(parser)                   # --exts with your '+webp' semantics
     args = parser.parse_args(argv)
 
-    # Structured logging
-    run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
-    if args.log_file:
-        configure_logging(log_level=args.log_level, file_mode="fixed", log_file=args.log_file, run_id=run_id, stage="merge")
-    else:
-        configure_logging(log_level=args.log_level, file_mode="auto", run_id=run_id, stage="merge")
-    t0 = time.time()
-
     # Resolve config (config-first with CLI fallback)
     cfg = build_merge_config(args.config, overrides=args.override)
     log.info("config.resolved", extra={"config": to_dict(cfg)})
+
+    # Structured logging
+    run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
+    log_level = cfg.log_level or args.log_level or "INFO"
+    log_file  = cfg.log_file or args.log_file or None
+
+    configure_logging(
+        log_level=log_level,
+        file_mode="fixed" if log_file else "auto",
+        log_file=log_file,
+        run_id=run_id,
+        stage="merge",
+    )
+    t0 = time.time()
 
     dataset_slug = os.getenv("DATASET_SLUG", cfg.dataset or args.dataset)
     pointer = cfg.pointer or args.pointer or _pointer_path_for(dataset_slug)

--- a/src/pipeline/merge.py
+++ b/src/pipeline/merge.py
@@ -120,7 +120,6 @@ def main(argv=None) -> int:
 
     # Resolve config (config-first with CLI fallback)
     cfg = build_merge_config(args.config, overrides=args.override)
-    log.info("config.resolved", extra={"config": to_dict(cfg)})
 
     # Structured logging
     run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
@@ -134,6 +133,8 @@ def main(argv=None) -> int:
         run_id=run_id,
         stage="merge",
     )
+    log.info("config.resolved", extra={"config": to_dict(cfg)})
+    
     t0 = time.time()
 
     dataset_slug = os.getenv("DATASET_SLUG", cfg.dataset or args.dataset)

--- a/src/pipeline/merge.py
+++ b/src/pipeline/merge.py
@@ -123,8 +123,8 @@ def main(argv=None) -> int:
 
     # Structured logging
     run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
-    log_level = cfg.log_level or args.log_level or "INFO"
-    log_file  = cfg.log_file or args.log_file or None
+    log_level = (getattr(cfg.log, "level", None) or args.log_level or "INFO")
+    log_file  = (getattr(cfg.log, "file",  None) or args.log_file  or None)
 
     configure_logging(
         log_level=log_level,

--- a/src/pipeline/resize.py
+++ b/src/pipeline/resize.py
@@ -250,7 +250,21 @@ def main(argv=None) -> int:
 
     # Run-aware logging (ties logs across stages in Docker/CI)
     run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
-    configure_logging(log_level=args.log_level, log_file=args.log_file, run_id=run_id, stage="resize")
+    if args.log_file:
+        configure_logging(
+            log_level=args.log_level,
+            file_mode="fixed",
+            log_file=args.log_file,
+            run_id=run_id,
+            stage="resize",
+        )
+    else:
+        configure_logging(
+            log_level=args.log_level,
+            file_mode="auto",
+            run_id=run_id,
+            stage="resize",
+        )
 
     # Resolve config-first (YAML + overrides), with CLI fallback for backward compat
     cfg = build_resize_config(args.config, overrides=args.override)

--- a/src/pipeline/resize.py
+++ b/src/pipeline/resize.py
@@ -250,7 +250,6 @@ def main(argv=None) -> int:
 
     # Resolve config-first (YAML + overrides), with CLI fallback for backward compat
     cfg = build_resize_config(args.config, overrides=args.override)
-    log.info("config.resolved", extra={"config": to_dict(cfg)})
 
     # Run-aware logging (ties logs across stages in Docker/CI)
     run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
@@ -264,6 +263,7 @@ def main(argv=None) -> int:
         run_id=run_id,
         stage="resize",
     )
+    log.info("config.resolved", extra={"config": to_dict(cfg)})
 
     train_in  = (cfg.train_in  if cfg.train_in  is not None else args.train_in)  or MERGED_DIR
     train_out = (cfg.train_out if cfg.train_out is not None else args.train_out) or PROCESSED_DIR

--- a/src/pipeline/resize.py
+++ b/src/pipeline/resize.py
@@ -253,8 +253,8 @@ def main(argv=None) -> int:
 
     # Run-aware logging (ties logs across stages in Docker/CI)
     run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
-    log_level = cfg.log_level or args.log_level or "INFO"
-    log_file  = cfg.log_file or args.log_file or None
+    log_level = (getattr(cfg.log, "level", None) or args.log_level or "INFO")
+    log_file  = (getattr(cfg.log, "file",  None) or args.log_file  or None)
 
     configure_logging(
         log_level=log_level,

--- a/src/pipeline/resize.py
+++ b/src/pipeline/resize.py
@@ -248,27 +248,22 @@ def main(argv=None) -> int:
     add_exts_arg(parser)             # --exts semantics (supports '+ext' and 'all')
     args = parser.parse_args(argv)
 
-    # Run-aware logging (ties logs across stages in Docker/CI)
-    run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
-    if args.log_file:
-        configure_logging(
-            log_level=args.log_level,
-            file_mode="fixed",
-            log_file=args.log_file,
-            run_id=run_id,
-            stage="resize",
-        )
-    else:
-        configure_logging(
-            log_level=args.log_level,
-            file_mode="auto",
-            run_id=run_id,
-            stage="resize",
-        )
-
     # Resolve config-first (YAML + overrides), with CLI fallback for backward compat
     cfg = build_resize_config(args.config, overrides=args.override)
     log.info("config.resolved", extra={"config": to_dict(cfg)})
+
+    # Run-aware logging (ties logs across stages in Docker/CI)
+    run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
+    log_level = cfg.log_level or args.log_level or "INFO"
+    log_file  = cfg.log_file or args.log_file or None
+
+    configure_logging(
+        log_level=log_level,
+        file_mode="fixed" if log_file else "auto",
+        log_file=log_file,
+        run_id=run_id,
+        stage="resize",
+    )
 
     train_in  = (cfg.train_in  if cfg.train_in  is not None else args.train_in)  or MERGED_DIR
     train_out = (cfg.train_out if cfg.train_out is not None else args.train_out) or PROCESSED_DIR

--- a/src/pipeline/split.py
+++ b/src/pipeline/split.py
@@ -150,36 +150,28 @@ def main(argv=None) -> int:
     add_common_logging_args(parser)
 
     args = parser.parse_args(argv or [])
-
-    # Logging
-    log_level = getattr(args, "log_level", "INFO")
-    log_file = getattr(args, "log_file", None)
-    run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
-    if log_file:
-        configure_logging(
-            log_level=log_level,
-            file_mode="fixed",
-            log_file=log_file,
-            run_id=run_id,
-            stage="split",
-        )
-    else:
-        configure_logging(
-            log_level=log_level,
-            file_mode="auto",
-            run_id=run_id,
-            stage="split",
-        )
-    log.info("split.dispatch", extra={"argv": argv})
-
     # Resolve config
     cfg = build_split_config(args.config, args.override or [])
+    # Logging
+    run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
+    log_level = cfg.log_level or args.log_level or "INFO"
+    log_file  = cfg.log_file or args.log_file or None
+
+    configure_logging(
+        log_level=log_level,
+        file_mode="fixed" if log_file else "auto",
+        log_file=log_file,
+        run_id=run_id,
+        stage="split",
+    )
+
+    log.info("split.dispatch", extra={"argv": argv})
+
     dataset_slug = cfg.dataset or args.dataset
     test_frac = cfg.test_frac if getattr(cfg, "test_frac", None) is not None else args.test_frac
     val_frac = cfg.val_frac if getattr(cfg, "val_frac", None) is not None else args.val_frac
     seed = cfg.seed if getattr(cfg, "seed", None) is not None else args.seed
     clear_dest = bool(getattr(cfg, "clear_dest", False) or getattr(args, "clear_dest", False))
-
     exts = parse_exts(args.exts)  # set[str] or empty set for "all"
 
     # Guard: fractions must be provided by YAML or CLI

--- a/src/pipeline/split.py
+++ b/src/pipeline/split.py
@@ -152,6 +152,7 @@ def main(argv=None) -> int:
     args = parser.parse_args(argv or [])
     # Resolve config
     cfg = build_split_config(args.config, args.override or [])
+
     # Logging
     run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
     log_level = cfg.log_level or args.log_level or "INFO"

--- a/src/pipeline/split.py
+++ b/src/pipeline/split.py
@@ -155,8 +155,8 @@ def main(argv=None) -> int:
 
     # Logging
     run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
-    log_level = cfg.log_level or args.log_level or "INFO"
-    log_file  = cfg.log_file or args.log_file or None
+    log_level = (getattr(cfg.log, "level", None) or args.log_level or "INFO")
+    log_file  = (getattr(cfg.log, "file",  None) or args.log_file  or None)
 
     configure_logging(
         log_level=log_level,

--- a/src/pipeline/split.py
+++ b/src/pipeline/split.py
@@ -155,7 +155,21 @@ def main(argv=None) -> int:
     log_level = getattr(args, "log_level", "INFO")
     log_file = getattr(args, "log_file", None)
     run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
-    configure_logging(log_level=log_level, log_file=log_file, run_id=run_id, stage="split")
+    if log_file:
+        configure_logging(
+            log_level=log_level,
+            file_mode="fixed",
+            log_file=log_file,
+            run_id=run_id,
+            stage="split",
+        )
+    else:
+        configure_logging(
+            log_level=log_level,
+            file_mode="auto",
+            run_id=run_id,
+            stage="split",
+        )
     log.info("split.dispatch", extra={"argv": argv})
 
     # Resolve config

--- a/src/pipeline/train.py
+++ b/src/pipeline/train.py
@@ -132,17 +132,12 @@ def main(argv=None) -> int:
     train_in = Path(cfg.data.train_in) if cfg.data.train_in else args.train_in
     val_in = Path(cfg.val_in) if getattr(cfg, "val_in", None) else None
     val_frac_effective = 0.0 if val_in else cfg.data.val_frac
-    # Effective val_frac: disabled when an explicit val_in is provided
-    val_frac_effective = 0.0 if val_in else cfg.data.val_frac
 
     mapping_pointer = getattr(cfg.data, "mapping_pointer", None) or getattr(args, "mapping_pointer", None)
     mapping_path = cfg.data.mapping_path or getattr(args, "index_remap", None)
 
     # ---- Dry run (plan only) ----
     if args.dry_run or getattr(cfg, "dry_run", False):
-        train_in = Path(cfg.data.train_in) if cfg.data.train_in else Path(args.train_in) if args.train_in else None
-        val_in = Path(cfg.data.val_in) if getattr(cfg.data, "val_in", None) else None 
-        mapping_path = cfg.data.mapping_path or getattr(args, "index_remap", None)
 
         train_exists = train_in.exists() if train_in else False
         val_exists = val_in.exists() if val_in else False
@@ -226,10 +221,6 @@ def main(argv=None) -> int:
         log.error("train.mapping_missing", extra={"hint": "Provide data.mapping_pointer or data.mapping_path"})
         return 2
     
-    # Prefer pre-split validation set when provided; otherwise use val_frac
-    
-
-
     out_models  = Path(cfg.io.out_models)  if not isinstance(cfg.io.out_models, Path)  else cfg.io.out_models
     out_summary = Path(cfg.io.out_summary) if not isinstance(cfg.io.out_summary, Path) else cfg.io.out_summary
     # ---- Build runner inputs and execute training ----

--- a/src/pipeline/train.py
+++ b/src/pipeline/train.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 from pathlib import Path
 import argparse, os
 from datetime import datetime, timezone
+from typing import Optional
 
 from src.utils.logging_utils import configure_logging, get_logger
 
@@ -126,6 +127,13 @@ def main(argv=None) -> int:
     # ---- Build config ----
     cfg = build_train_config(args.config, overrides=args.override)
     log.info("config.resolved", extra={"config": to_dict(cfg)})
+
+    # Resolve training/validation inputs
+    train_in = Path(cfg.data.train_in) if cfg.data.train_in else args.train_in
+    val_in = Path(cfg.val_in) if getattr(cfg, "val_in", None) else None
+    val_frac_effective = 0.0 if val_in else cfg.data.val_frac
+    # Effective val_frac: disabled when an explicit val_in is provided
+    val_frac_effective = 0.0 if val_in else cfg.data.val_frac
 
     mapping_pointer = getattr(cfg.data, "mapping_pointer", None) or getattr(args, "mapping_pointer", None)
     mapping_path = cfg.data.mapping_path or getattr(args, "index_remap", None)
@@ -219,8 +227,7 @@ def main(argv=None) -> int:
         return 2
     
     # Prefer pre-split validation set when provided; otherwise use val_frac
-    val_in = Path(cfg.data.val_in) if getattr(cfg.data, "val_in", None) else None
-    val_frac_effective = 0.0 if val_in else cfg.data.val_frac
+    
 
 
     out_models  = Path(cfg.io.out_models)  if not isinstance(cfg.io.out_models, Path)  else cfg.io.out_models
@@ -228,7 +235,7 @@ def main(argv=None) -> int:
     # ---- Build runner inputs and execute training ----
     inputs = TrainRunnerInputs(
         image_size=cfg.data.image_size,
-        train_in=Path(cfg.data.train_in) if cfg.data.train_in else args.train_in,
+        train_in=train_in,
         val_in=val_in,  
         batch_size=cfg.data.batch_size,
         num_workers=cfg.data.num_workers,

--- a/src/pipeline/train.py
+++ b/src/pipeline/train.py
@@ -119,8 +119,8 @@ def main(argv=None) -> int:
     
     # Run-aware logging (ties logs across stages)
     run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
-    log_level = cfg.log_level or args.log_level or "INFO"
-    log_file  = cfg.log_file or args.log_file or None
+    log_level = (getattr(cfg.log, "level", None) or args.log_level or "INFO")
+    log_file  = (getattr(cfg.log, "file",  None) or args.log_file  or None)
 
     configure_logging(
         log_level=log_level,

--- a/src/pipeline/train.py
+++ b/src/pipeline/train.py
@@ -114,19 +114,24 @@ def main(argv=None) -> int:
     parser = make_parser_train()
     args = parser.parse_args(argv)
 
-    # Run-aware logging (ties logs across stages)
-    run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
-    if args.log_file:
-        configure_logging(log_level=args.log_level, file_mode="fixed", log_file=args.log_file, run_id=run_id, stage="train")
-    else:
-        configure_logging(log_level=args.log_level, file_mode="auto", run_id=run_id, stage="train")
-
-    bootstrap_env(seed=args.seed)
-    log_env_once()
-
     # ---- Build config ----
     cfg = build_train_config(args.config, overrides=args.override)
     log.info("config.resolved", extra={"config": to_dict(cfg)})
+    
+    # Run-aware logging (ties logs across stages)
+    run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
+    log_level = cfg.log_level or args.log_level or "INFO"
+    log_file  = cfg.log_file or args.log_file or None
+
+    configure_logging(
+        log_level=log_level,
+        file_mode="fixed" if log_file else "auto",
+        log_file=log_file,
+        run_id=run_id,
+        stage="train",
+    )
+    bootstrap_env(seed=args.seed)
+    log_env_once()
 
     # Resolve training/validation inputs
     train_in = Path(cfg.data.train_in) if cfg.data.train_in else args.train_in

--- a/src/pipeline/train.py
+++ b/src/pipeline/train.py
@@ -116,7 +116,6 @@ def main(argv=None) -> int:
 
     # ---- Build config ----
     cfg = build_train_config(args.config, overrides=args.override)
-    log.info("config.resolved", extra={"config": to_dict(cfg)})
     
     # Run-aware logging (ties logs across stages)
     run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
@@ -130,6 +129,8 @@ def main(argv=None) -> int:
         run_id=run_id,
         stage="train",
     )
+    log.info("config.resolved", extra={"config": to_dict(cfg)})
+    
     bootstrap_env(seed=args.seed)
     log_env_once()
 

--- a/src/pipeline/validate.py
+++ b/src/pipeline/validate.py
@@ -459,7 +459,7 @@ def validate_dataset(
 
                                 if not same_class or score < ssim_thresh:
                                     # Keep the visibility log, but do not record a warning
-                                    log.info(f"[PHASH_REJECTED] {p} vs {prev_path} (d={d}, ssim={score:.3f})")
+                                    log.debug(f"[PHASH_REJECTED] {p} vs {prev_path} (d={d}, ssim={score:.3f})")
                                     continue
 
                                 # Track the best acceptable candidate (lowest Hamming, then highest SSIM)

--- a/src/pipeline/validate.py
+++ b/src/pipeline/validate.py
@@ -592,7 +592,6 @@ def main(argv=None) -> int:
 
     # Config-first
     cfg = build_validate_config(args.config, overrides=args.override)
-    log.info("config.resolved", extra={"config": to_dict(cfg)})
 
     # Run-aware logging (ties logs across stages)
     run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
@@ -605,8 +604,10 @@ def main(argv=None) -> int:
         file_mode="fixed" if log_file else "auto",
         log_file=log_file,
         run_id=run_id,
-        stage="merge",
+        stage="validate",
     )
+
+    log.info("config.resolved", extra={"config": to_dict(cfg)})
 
     # choose in_dir: explicit > arg > mode-based default
     if cfg.in_dir is not None:

--- a/src/pipeline/validate.py
+++ b/src/pipeline/validate.py
@@ -590,15 +590,23 @@ def main(argv=None) -> int:
 
     args = parser.parse_args(argv)
 
-    # Run-aware logging (ties logs across stages)
-    run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
-    if args.log_file:
-        configure_logging(log_level=args.log_level, file_mode="fixed", log_file=args.log_file, run_id=run_id, stage="validate")
-    else:
-        configure_logging(log_level=args.log_level, file_mode="auto", run_id=run_id, stage="validate")
-
+    # Config-first
     cfg = build_validate_config(args.config, overrides=args.override)
     log.info("config.resolved", extra={"config": to_dict(cfg)})
+
+    # Run-aware logging (ties logs across stages)
+    run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
+    
+    log_level = cfg.log_level or args.log_level or "INFO"
+    log_file  = cfg.log_file or args.log_file or None
+
+    configure_logging(
+        log_level=log_level,
+        file_mode="fixed" if log_file else "auto",
+        log_file=log_file,
+        run_id=run_id,
+        stage="merge",
+    )
 
     # choose in_dir: explicit > arg > mode-based default
     if cfg.in_dir is not None:

--- a/src/pipeline/validate.py
+++ b/src/pipeline/validate.py
@@ -596,8 +596,8 @@ def main(argv=None) -> int:
     # Run-aware logging (ties logs across stages)
     run_id = os.getenv("RUN_ID") or datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%SZ")
     
-    log_level = cfg.log_level or args.log_level or "INFO"
-    log_file  = cfg.log_file or args.log_file or None
+    log_level = (getattr(cfg.log, "level", None) or args.log_level or "INFO")
+    log_file  = (getattr(cfg.log, "file",  None) or args.log_file  or None)
 
     configure_logging(
         log_level=log_level,

--- a/src/utils/logging_utils.py
+++ b/src/utils/logging_utils.py
@@ -148,8 +148,9 @@ def configure_logging(
     # Decide file path (if any)
     file_path: Path | None = None
     if file_mode == "auto":
-        script_name = Path(sys.argv[0]).stem or "app"
-        file_path = logs_root / f"{script_name}.log"
+        base = (stage or Path(sys.argv[0]).stem or "app")
+        suffix = f"_{run_id}" if run_id else ""
+        file_path = logs_root / f"{base}{suffix}.log"
     elif file_mode == "fixed":
         file_path = logs_root / (Path(log_file).name if log_file else "app.log")
     elif file_mode == "none":


### PR DESCRIPTION
## refactor(logging): unify config-first logging across all stages

### Changes
- Added `LoggingConfig` dataclass and embedded it in all stage configs.
- Stage builders fold legacy `log_level` / `log_file` into `log.{level,file}` (backward compatible).
- All stages now build config **before** configuring logging.
- Logging resolution order:
  - config value → CLI arg → default
- Config is logged **after** logging is configured to ensure it’s captured in stage logs.
- Retained `--log-level` / `--log-file` args for standalone runs and tests.

### Benefits
- Consistent logging setup across fetch, merge, resize, split, train, validate, evaluate, cleanup.
- Config-first behavior with CLI fallback.
- Cleaner schema; centralized logging config.
- Backward compatibility with existing YAML and CLI usage.
