### PR TITLE
Feat/validate-identity-groups

### DIFF
--- a/src/configs/pipeline.yaml
+++ b/src/configs/pipeline.yaml
@@ -1,6 +1,6 @@
 # Master pipeline configuration for brain tumor classification
 
-run_id: bt-exp-011
+run_id: bt-exp-012
 
 env:
   seed: 42

--- a/src/configs/pipeline.yaml
+++ b/src/configs/pipeline.yaml
@@ -1,6 +1,6 @@
 # Master pipeline configuration for brain tumor classification
 
-run_id: bt-exp-012
+run_id: bt-exp-013
 
 env:
   seed: 42

--- a/src/core/cleanup_policy.py
+++ b/src/core/cleanup_policy.py
@@ -12,7 +12,8 @@ Defines:
 STRICT_ERROR_CODES = {
     "UNREADABLE", "READ_FAIL", "STAT_FAIL", "TINY_FILE",
     "NOT_RGB", "BAD_SIZE", "ALL_BLACK", "ALL_WHITE",
-    "DUPLICATE","NEAR_DUP_PHASH",
+    "DUPLICATE","NEAR_DUP_PHASH", "CROSSCLASS_DUP",
+    "CROSSCLASS_NEAR_DUP",
 }
 
 # Codes we never auto-move (contract/mapping issues)

--- a/src/pipeline/cleanup.py
+++ b/src/pipeline/cleanup.py
@@ -151,6 +151,7 @@ def _plan_moves(
     """
     planned: List[Tuple[Path, Path, Finding]] = []
     counts_by_code: Dict[str, int] = defaultdict(int)
+    planned_srcs: set[str] = set()
 
     # Build quick path->(subset,label) index
     idx = _path_index_from_findings(findings)
@@ -171,6 +172,31 @@ def _plan_moves(
 
         # Decide if this finding should be acted on
         if not _should_act_on(f.kind, f.code, policy, act_on):
+            continue
+
+        # NEW: Cross-class duplicates -> remove ALL copies (both sides)
+        if f.code in {"CROSSCLASS_DUP", "CROSSCLASS_NEAR_DUP"}:
+            # Queue current file
+            if str(src) not in planned_srcs:
+                planned.append((src, dst, f))
+                planned_srcs.add(str(src))
+                counts_by_code[f.code] += 1
+
+            # Queue the counterpart (duplicate_of), if known
+            if f.duplicate_of:
+                other_path = Path(f.duplicate_of)
+                # Figure out subset/label for the counterpart from findings index; fallback to path
+                other_subset, other_label = idx.get(str(other_path), (None, None))
+                if not other_subset or not other_label:
+                    other_subset, other_label = _derive_subset_label_from_path(other_path)
+
+                other_dst = QUARANTINE_ROOT / run_id / (other_subset or "unknown_subset") / (other_label or "unknown_label") / other_path.name
+
+                if str(other_path) not in planned_srcs:
+                    planned.append((other_path, other_dst, f))
+                    planned_srcs.add(str(other_path))
+                    counts_by_code[f.code] += 1
+            # Done with this finding
             continue
 
         # Special handling for duplicates based on policy

--- a/src/pipeline/validate.py
+++ b/src/pipeline/validate.py
@@ -420,13 +420,25 @@ def validate_dataset(
                     used_sig = content_sig if content_sig in seen_content_hashes else content_sig_flip
 
                 if dup_hit and first_path is not None:
-                    log.error(f"[DUPLICATE] {p} dup of {first_path}")
+                    # Determine if the duplicate crosses class boundaries
+                    cur_label = p.parent.name
+                    first_label = first_path.parent.name
+                    same_label = (cur_label == first_label)
+
+                    code = "DUPLICATE" if same_label else "CROSSCLASS_DUP"
+                    log.error(f"[{code}] {p} dup of {first_path} (cur_label={cur_label}, first_label={first_label})")
                     n_errors += 1
                     _record(
-                        "error", "DUPLICATE", p, label=label,
+                        "error", code, p, label=label,
                         sha1=used_sig,                     # key used by cleanup
                         duplicate_of=str(first_path),
-                        details={"file_sha1": file_sig, "content_sha1": content_sig, "mode": "both"},
+                        details={
+                            "file_sha1": file_sig,
+                            "content_sha1": content_sig,
+                            "mode": "both",
+                            "cur_label": cur_label,
+                            "first_label": first_label,
+                        },
                     )
                     dup_groups.setdefault(used_sig, [str(first_path)])
                     if str(p) not in dup_groups[used_sig]:
@@ -457,9 +469,32 @@ def validate_dataset(
                                 score = _ssim_similarity(p, prev_path, size=size)
                                 same_class = (p.parent.name == prev_path.parent.name)
 
-                                if not same_class or score < ssim_thresh:
+                                if score < ssim_thresh:
                                     # Keep the visibility log, but do not record a warning
                                     log.debug(f"[PHASH_REJECTED] {p} vs {prev_path} (d={d}, ssim={score:.3f})")
+                                    continue
+
+                                # Cross-class near-duplicate => error, recorded immediately
+                                if not same_class:
+                                    cur_label = p.parent.name
+                                    other_label = prev_path.parent.name
+                                    log.error(
+                                        f"[CROSSCLASS_NEAR_DUP] {p} ~ {prev_path} "
+                                        f"(cur_label={cur_label}, other_label={other_label}; d={d}, ssim={score:.3f})"
+                                    )
+                                    n_errors += 1
+                                    _record(
+                                        "error", "CROSSCLASS_NEAR_DUP", p, label=label,
+                                        details={
+                                            "hamming": int(d),
+                                            "threshold": int(phash_thresh),
+                                            "ssim": round(score, 3),
+                                            "cur_label": cur_label,
+                                            "other_label": other_label,
+                                        },
+                                        duplicate_of=str(prev_path),
+                                    )
+                                    # Do not consider cross-class pairs for same-class best tracking
                                     continue
 
                                 # Track the best acceptable candidate (lowest Hamming, then highest SSIM)

--- a/src/pipeline/validate.py
+++ b/src/pipeline/validate.py
@@ -495,7 +495,7 @@ def validate_dataset(
                                         duplicate_of=str(prev_path),
                                     )
                                     # Do not consider cross-class pairs for same-class best tracking
-                                    continue
+                                    break
 
                                 # Track the best acceptable candidate (lowest Hamming, then highest SSIM)
                                 if (best_path is None) or (d < best_dist) or (d == best_dist and score > best_ssim):

--- a/src/tests/pipeline/test_cleanup.py
+++ b/src/tests/pipeline/test_cleanup.py
@@ -328,7 +328,6 @@ def test_cli_dry_run_crossclass_near_dup_plans_both(tmp_path, monkeypatch, capsy
             "--override", "dry_run=true",
         ]
     )
-    out = capsys.readouterr().out
     assert code == 0
     # Plan file should list two items (both sides)
     plan_file = (tmp_path / "cleanup_reports" / "cleanup_plan_RIDNEAR.json")

--- a/src/tests/pipeline/test_cleanup.py
+++ b/src/tests/pipeline/test_cleanup.py
@@ -335,5 +335,5 @@ def test_cli_dry_run_crossclass_near_dup_plans_both(tmp_path, monkeypatch, capsy
     assert plan_file.exists()
     plan = json.loads(plan_file.read_text())
     assert plan["planned_count"] == 2
-    srcs = {item["src"] for item in plan["items"]}
+    srcs = {item["from"] for item in plan["items"]}
     assert srcs == {str(a), str(b)}

--- a/src/tests/pipeline/test_cleanup.py
+++ b/src/tests/pipeline/test_cleanup.py
@@ -254,3 +254,86 @@ def test_cli_report_latest_with_tag_resolution(tmp_path, monkeypatch, capsys):
         or "[REPORT-ONLY] Planned moves: 0" in out
     )
 
+
+def test_plan_moves_crossclass_duplicate_removes_both(tmp_path, monkeypatch):
+    cleanup = _import_cleanup(monkeypatch, tmp_path)
+
+    # First-occurrence path (in glioma)
+    first_path = tmp_path / "data" / "train" / "glioma" / "x.jpg"
+    first_path.parent.mkdir(parents=True, exist_ok=True)
+    first_path.write_bytes(b"imgx")
+
+    # Cross-class duplicate finding (in meningioma), pointing to first_path
+    cross = cleanup.Finding(
+        path=str(tmp_path / "data" / "train" / "meningioma" / "y.jpg"),
+        label="meningioma",
+        subset="train",
+        kind="error",
+        code="CROSSCLASS_DUP",
+        sha1="abc123",
+        duplicate_of=str(first_path),
+    )
+    # ensure counterpart file exists too
+    yfile = tmp_path / "data" / "train" / "meningioma" / "y.jpg"
+    yfile.parent.mkdir(parents=True, exist_ok=True)
+    yfile.write_bytes(b"imgy")
+
+    planned, counts = cleanup._plan_moves([cross], policy="strict", act_on="both", run_id="RIDX")
+
+    # Should plan to move BOTH: the current path and its duplicate_of counterpart
+    assert len(planned) == 2
+    # Planned sources (unordered)
+    planned_srcs = {str(p[0]) for p in planned}
+    assert planned_srcs == {str(yfile), str(first_path)}
+    # Count both under the same code
+    assert counts["CROSSCLASS_DUP"] == 2
+
+
+def test_cli_dry_run_crossclass_near_dup_plans_both(tmp_path, monkeypatch, capsys):
+    cleanup = _import_cleanup(monkeypatch, tmp_path)
+
+    # Files referenced by the report
+    a = tmp_path / "data" / "train" / "glioma" / "a.jpg"
+    b = tmp_path / "data" / "train" / "meningioma" / "b.jpg"
+    a.parent.mkdir(parents=True, exist_ok=True)
+    b.parent.mkdir(parents=True, exist_ok=True)
+    a.write_bytes(b"A")
+    b.write_bytes(b"B")
+
+    # Pre-validation report with a single CROSSCLASS_NEAR_DUP finding
+    report_path = tmp_path / "vr_cross.json"
+    report = {
+        "findings": [
+            {
+                "path": str(b),
+                "label": "meningioma",
+                "subset": "train",
+                "kind": "error",
+                "code": "CROSSCLASS_NEAR_DUP",
+                "duplicate_of": str(a),
+                "details": {"hamming": 4, "ssim": 0.95, "cur_label": "meningioma", "other_label": "glioma"},
+            }
+        ]
+    }
+    report_path.write_text(json.dumps(report), encoding="utf-8")
+
+    os.environ["RUN_ID"] = "RIDNEAR"
+
+    code = _run_main(
+        cleanup,
+        [
+            "--override", f"report={report_path}",
+            "--override", "policy=strict",
+            "--override", "why=both",
+            "--override", "dry_run=true",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert code == 0
+    # Plan file should list two items (both sides)
+    plan_file = (tmp_path / "cleanup_reports" / "cleanup_plan_RIDNEAR.json")
+    assert plan_file.exists()
+    plan = json.loads(plan_file.read_text())
+    assert plan["planned_count"] == 2
+    srcs = {item["src"] for item in plan["items"]}
+    assert srcs == {str(a), str(b)}

--- a/src/tests/pipeline/test_validate_duplicates.py
+++ b/src/tests/pipeline/test_validate_duplicates.py
@@ -94,6 +94,110 @@ def tiny_ds(tmp_path: Path):
 
 
 # ---------- tests ----------
+def test_crossclass_exact_duplicate_flags_error(tiny_ds: Path):
+    """
+    Exact byte-for-byte duplicate across labels must emit CROSSCLASS_DUP (error)
+    and increment errors_by_type accordingly.
+    """
+    # Make an exact copy of glioma/a.png into meningioma/
+    src = tiny_ds / "glioma" / "a.png"
+    dst = tiny_ds / "meningioma" / "a_copy_from_glioma.png"
+    dst.write_bytes(src.read_bytes())
+
+    summary = validate_dataset(
+        in_dir=tiny_ds,
+        index_remap_path=None,
+        size=224,
+        exts=".png,.jpg,.jpeg",
+        dup_check=True,
+        warn_low_std=0.0,
+        min_file_bytes=1,
+        enforce_size=True,
+        require_rgb=True,
+        phash=False,   # not needed for exact dup
+    )
+
+    # New code present and counted as error
+    assert summary["errors_by_type"].get("CROSSCLASS_DUP", 0) >= 1
+
+    # Finding includes duplicate_of and both labels in details
+    recs = _findings(summary, code="CROSSCLASS_DUP", path_endswith="meningioma/a_copy_from_glioma.png")
+    assert len(recs) == 1
+    r = recs[0]
+    assert r.get("duplicate_of")
+    assert r["details"]["cur_label"] == "meningioma"
+    assert r["details"]["first_label"] == "glioma"
+
+
+def test_crossclass_near_duplicate_phash_flags_error(tiny_ds: Path):
+    """
+    Near-duplicate across labels (pHash within threshold + SSIM >= thresh)
+    must emit CROSSCLASS_NEAR_DUP (error).
+    """
+    # Move the JPEG near-dup to the other class to force cross-class detection
+    src = tiny_ds / "glioma" / "a_jpeg.jpg"
+    dst = tiny_ds / "meningioma" / "a_jpeg_cross.jpg"
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if src.exists():
+        dst.write_bytes(src.read_bytes())
+        src.unlink()
+
+    summary = validate_dataset(
+        in_dir=tiny_ds,
+        index_remap_path=None,
+        size=224,
+        exts=".png,.jpg,.jpeg",
+        dup_check=True,
+        warn_low_std=0.0,
+        min_file_bytes=1,
+        enforce_size=True,
+        require_rgb=True,
+        phash=True,           # enable perceptual hash
+        phash_thresh=8,
+        ssim_thresh=0.90,     # uses current default; adjust if you changed it
+    )
+
+    # Should be counted as error (not warning)
+    assert summary["errors_by_type"].get("CROSSCLASS_NEAR_DUP", 0) >= 1
+    assert summary["warnings_by_type"].get("NEAR_DUP_PHASH", 0) >= 0  # may still exist for same-class cases
+
+    recs = _findings(summary, code="CROSSCLASS_NEAR_DUP", path_endswith="meningioma/a_jpeg_cross.jpg")
+    assert len(recs) == 1
+    r = recs[0]
+    assert r.get("duplicate_of")
+    assert "hamming" in r["details"]
+    assert "ssim" in r["details"]
+    assert 0.0 <= r["details"]["ssim"] <= 1.0
+    assert r["details"]["cur_label"] == "meningioma"
+    assert r["details"]["other_label"] == "glioma"
+
+
+def test_sameclass_near_duplicate_stays_warning(tiny_ds: Path):
+    """
+    Same-class near-duplicates must remain NEAR_DUP_PHASH (warning) and not be
+    promoted to error codes.
+    """
+    summary = validate_dataset(
+        in_dir=tiny_ds,
+        index_remap_path=None,
+        size=224,
+        exts=".png,.jpg,.jpeg",
+        dup_check=True,
+        warn_low_std=0.0,
+        min_file_bytes=1,
+        enforce_size=True,
+        require_rgb=True,
+        phash=True,
+        phash_thresh=8,
+        ssim_thresh=0.90,
+    )
+    # Expect at least one same-class near-dup warning (from glioma/a_jpeg.jpg vs a.png)
+    assert summary["warnings_by_type"].get("NEAR_DUP_PHASH", 0) >= 1
+    # No cross-class errors should appear in this test (dataset as-is is single-class for near-dup)
+    assert summary["errors_by_type"].get("CROSSCLASS_NEAR_DUP", 0) == 0
+
+    
+
 def test_validate_exact_duplicate_filehash(tiny_ds: Path):
     """Flags exact byte-for-byte duplicates via file SHA-1."""
     summary = validate_dataset(


### PR DESCRIPTION
### Summary
This PR extends the validation and cleanup stages to handle **cross-class duplicates**.  
Any image found duplicated across different labels is now flagged and all copies are quarantined.

### Changes
- **validate.py**
  - Emit `CROSSCLASS_DUP` for exact/content duplicates across labels.
  - Emit `CROSSCLASS_NEAR_DUP` for pHash+SSIM near-duplicates across labels.
  - Preserve existing behavior for within-class duplicates (`DUPLICATE`, `NEAR_DUP_PHASH`).

- **cleanup_policy.py**
  - Added `CROSSCLASS_DUP` and `CROSSCLASS_NEAR_DUP` to `STRICT_ERROR_CODES`.

- **cleanup.py**
  - `_plan_moves` now removes *both sides* of cross-class duplicate pairs/groups.
  - Added `planned_srcs` set to avoid duplicate move entries.

### Why
Cross-class duplicates undermine label integrity. Removing all copies ensures cleaner datasets and more reliable training data.

### Pipeline Impact
- `validate(pre)` will now report cross-class issues as **errors**.
- `cleanup` (strict policy) will automatically quarantine all copies of cross-class duplicates.
- `validate(post)` will confirm removal.
